### PR TITLE
Update README.md on PCL dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@
 
 The **default from apt** PCL and Eigen is enough for FAST-LIO to work normally.
 
+For PCL, if the default from apt `libpcl-dev` doesn't work for you, try to install `pcl_ros` with `sudo apt install ros-<ros2-distro>-pcl-ros` instead.
+
 ROS >= Foxy (Recommend to use ROS-Humble). [ROS Installation](https://docs.ros.org/en/humble/Installation.html)
 
 ### 1.2. **PCL && Eigen**
-PCL    >= 1.8,   Follow [PCL Installation](http://www.pointclouds.org/downloads/linux.html).
+PCL    >= 1.8,   Follow [PCL Installation](https://pointclouds.org/downloads/#linux).
 
 Eigen  >= 3.3.4, Follow [Eigen Installation](http://eigen.tuxfamily.org/index.php?title=Main_Page).
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@
 
 The **default from apt** PCL and Eigen is enough for FAST-LIO to work normally.
 
-For PCL, if the default from apt `libpcl-dev` doesn't work for you, try to install `pcl_ros` with `sudo apt install ros-<ros2-distro>-pcl-ros` instead.
-
 ROS >= Foxy (Recommend to use ROS-Humble). [ROS Installation](https://docs.ros.org/en/humble/Installation.html)
 
 ### 1.2. **PCL && Eigen**
@@ -93,6 +91,7 @@ Clone the repository and colcon build:
     cd <ros2_ws>/src # cd into a ros2 workspace folder
     git clone https://github.com/Ericsii/FAST_LIO.git --recursive
     cd ..
+    rosdep install --from-paths src --ignore-src -y
     colcon build --symlink-install
     . ./install/setup.bash # use setup.zsh if use zsh
 ```


### PR DESCRIPTION
Hi, thanks for the amazing work on porting FAST_LIO to ROS2!

I'm deploying FAST_LIO on an Nvidia Jetson with Ubuntu 22.04 and ROS 2 Humble and I found some disagreement between the README instructions and what actually happened. So I add my solution to the README.

Changes: 
- The PCL default from apt (`libpcl-dev`) doesn't work for me and FAST_LIO refuses to compile. After I installed `pcl_ros` the problem was fixed.
- The link for PCL installation no longer directs to a 404 site.

Jetson might not be the hardware people use the most to deploy FAST_LIO so I don't know if the problem is just for ARM arch or everyone. It would be nice if someone could help me verify this.

Thanks again for your work!