### PR TITLE
Fix mid360 lidar handler

### DIFF
--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -479,7 +479,7 @@ void Preprocess::mid360_handler(const sensor_msgs::msg::PointCloud2::UniquePtr &
   pl_corn.clear();
   pl_full.clear();
 
-  pcl::PointCloud<livox_ros::LivoxPointXyzrtl> pl_orig;
+  pcl::PointCloud<livox_ros::LivoxPointXyzitl> pl_orig;
   pcl::fromROSMsg(*msg, pl_orig);
   int plsize = pl_orig.points.size();
   if (plsize == 0)
@@ -516,7 +516,7 @@ void Preprocess::mid360_handler(const sensor_msgs::msg::PointCloud2::UniquePtr &
     added_pt.x = pl_orig.points[i].x;
     added_pt.y = pl_orig.points[i].y;
     added_pt.z = pl_orig.points[i].z;
-    added_pt.intensity = pl_orig.points[i].reflectivity;
+    added_pt.intensity = pl_orig.points[i].intensity;
     added_pt.curvature = 0.;
 
     int layer = pl_orig.points[i].line;

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -122,12 +122,30 @@ typedef struct {
   uint8_t tag;        /**< Livox point tag   */
   uint8_t line;       /**< Laser line id     */
 } LivoxPointXyzrtl;
+
+typedef struct {
+  float x;            /**< X axis, Unit:m */
+  float y;            /**< Y axis, Unit:m */
+  float z;            /**< Z axis, Unit:m */
+  float intensity;    /**< Intensity   */
+  uint8_t tag;        /**< Livox point tag   */
+  uint8_t line;       /**< Laser line id     */
+} LivoxPointXyzitl;
 }
 POINT_CLOUD_REGISTER_POINT_STRUCT(livox_ros::LivoxPointXyzrtl,
     (float, x, x)
     (float, y, y)
     (float, z, z)
     (float, reflectivity, reflectivity)
+    (uint8_t, tag, tag)
+    (uint8_t, line, line)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(livox_ros::LivoxPointXyzitl,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
     (uint8_t, tag, tag)
     (uint8_t, line, line)
 )


### PR DESCRIPTION
The Livox mid360 driver defines intensity in its PointCloud2 header not reflectivity.
The header is defined here: [lddc.cpp#L280](https://github.com/Livox-SDK/livox_ros_driver2/blob/6b9356cadf77084619ba406e6a0eb41163b08039/src/lddc.cpp#L280)

This PR replaces reflectivity with intensity.

I left the original LivoxPointXyzrtl definition but I don't believe it's used anywhere.