### PR TITLE
Fix typo in DeclareLaunchArgument for config_file

### DIFF
--- a/launch/mapping.launch.py
+++ b/launch/mapping.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
         'config_path', default_value=default_config_path,
         description='Yaml config file path'
     )
-    decalre_config_file_cmd = DeclareLaunchArgument(
+    declare_config_file_cmd = DeclareLaunchArgument(
         'config_file', default_value='mid360.yaml',
         description='Config file'
     )


### PR DESCRIPTION
Threre is an unfatal spelling mistake in launch file. 