### PR TITLE
Add mount orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,15 +198,15 @@ The main structure of this UAV is 3d printed (Aluminum or PLA), the .stl file wi
 Added configuration to allow different lidar mounting orientation. Can be used if the lidar mounting is not parallel to the floor, such as in unitree g1 or other similar robots.
 Modify mid360.yaml:
 ```
-use_base_link: true          # true: transform map to base_link frame -> change to false if you want to use camera_init frame
-base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
-base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
-base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link
+use_odom: true               # true: transform map to odom frame -> change to false if you want to use camera_init frame
+odom_roll: 180.0             # Roll angle (degrees) from camera_init to odom
+odom_pitch: -7.5             # Pitch angle (degrees) from camera_init to odom
+odom_yaw: 0.0                # Yaw angle (degrees) from camera_init to odom
 ```
 
 Transformation tree will become:
 ```
-base_link -> camera_init -> body (where map pointcloud will be saved in base_link frame)
+odom -> camera_init -> body (where map pointcloud will be saved in odom frame)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ The main structure of this UAV is 3d printed (Aluminum or PLA), the .stl file wi
     <img src="doc/uav_system.png" width=57% >
 </div>
 
-## 6.Acknowledgments
+## 6.Additional Features
+Added configuration to allow different lidar mounting orientation. Can be used if the lidar mounting is not parallel to the floor, such as in unitree g1 or other similar robots.
+Modify mid360.yaml:
+```
+use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting) -> change to false if the lidar orientation is not parallel to the floor
+base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
+base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
+base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link
+```
+
+
+## 7.Acknowledgments
 
 Thanks for LOAM(J. Zhang and S. Singh. LOAM: Lidar Odometry and Mapping in Real-time), [Livox_Mapping](https://github.com/Livox-SDK/livox_mapping), [LINS](https://github.com/ChaoqinRobotics/LINS---LiDAR-inertial-SLAM) and [Loam_Livox](https://github.com/hku-mars/loam_livox).

--- a/README.md
+++ b/README.md
@@ -195,13 +195,19 @@ The main structure of this UAV is 3d printed (Aluminum or PLA), the .stl file wi
 </div>
 
 ## 6.Additional Features
-Added configuration to allow different lidar mounting orientation. Can be used if the lidar mounting is not parallel to the floor, such as in unitree g1 or other similar robots.
+Added configuration to allow different lidar mounting orientation. Can be used if the lidar mounting is not parallel to the floor, such as in unitree g1 or other similar robots. 
+
+In this model, odom frame represent the initial position of the camera, similar to camera_init frame, but are relative to the floor in real life (or any orientation that we want)
+
 Modify mid360.yaml:
 ```
 use_odom: true               # true: transform map to odom frame -> change to false if you want to use camera_init frame
-odom_roll: 180.0             # Roll angle (degrees) from camera_init to odom
-odom_pitch: -7.5             # Pitch angle (degrees) from camera_init to odom
-odom_yaw: 0.0                # Yaw angle (degrees) from camera_init to odom
+odom_roll: 0.0             # Roll angle (degrees) from odom to camera_init
+odom_pitch: 0.0            # Pitch angle (degrees) from odom to camera_init
+odom_yaw: 0.0              # Yaw angle (degrees) from odom to camera_init
+odom_x: 0.0                # Translation x (meters) from odom to camera_init
+odom_y: 0.0                # Translation y (meters) from odom to camera_init
+odom_z: 0.0                # Translation z (meters) from odom to camera_init
 ```
 
 Transformation tree will become:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_li
 base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link
 ```
 
+Transformation tree will become:
+```
+base_link -> camera_init -> body (where map pointcloud will be saved in base_link frame)
+```
+
 
 ## 7.Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The main structure of this UAV is 3d printed (Aluminum or PLA), the .stl file wi
 Added configuration to allow different lidar mounting orientation. Can be used if the lidar mounting is not parallel to the floor, such as in unitree g1 or other similar robots.
 Modify mid360.yaml:
 ```
-use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting) -> change to false if the lidar orientation is not parallel to the floor
+use_base_link: true          # true: transform map to base_link frame -> change to false if you want to use camera_init frame
 base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
 base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
 base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -44,9 +44,12 @@
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
             use_odom: true               # true: transform map to odom frame -> change to false if you want to use camera_init frame
-            odom_roll: 180.0             # Roll angle (degrees) from camera_init to odom
-            odom_pitch: -7.5             # Pitch angle (degrees) from camera_init to odom
-            odom_yaw: 0.0                # Yaw angle (degrees) from camera_init to odom
+            odom_roll: 180.0             # Roll angle (degrees) from odom to camera_init
+            odom_pitch: -7.5             # Pitch angle (degrees) from odom to camera_init
+            odom_yaw: 0.0                # Yaw angle (degrees) from odom to camera_init
+            odom_x: 0.0                  # Translation x (meters) from odom to camera_init
+            odom_y: 0.0                  # Translation y (meters) from odom to camera_init
+            odom_z: 0.0                  # Translation z (meters) from odom to camera_init
 
         pcd_save:
             pcd_save_en: true

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -43,7 +43,7 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
-            use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting) -> change to false if the lidar orientation is not parallel to the floor
+            use_base_link: true          # true: transform map to base_link frame -> change to false if you want to use camera_init frame
             base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
             base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
             base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -43,10 +43,10 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
-            use_base_link: true          # true: transform map to base_link frame -> change to false if you want to use camera_init frame
-            base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
-            base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
-            base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link
+            use_odom: true               # true: transform map to odom frame -> change to false if you want to use camera_init frame
+            odom_roll: 180.0             # Roll angle (degrees) from camera_init to odom
+            odom_pitch: -7.5             # Pitch angle (degrees) from camera_init to odom
+            odom_yaw: 0.0                # Yaw angle (degrees) from camera_init to odom
 
         pcd_save:
             pcd_save_en: true

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -43,6 +43,10 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting)
+            base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
+            base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
+            base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link
 
         pcd_save:
             pcd_save_en: true

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -43,7 +43,7 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
-            use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting)
+            use_base_link_flip: true     # true: transform map to base_link frame (for upside-down LiDAR mounting) -> change to false if the lidar orientation is not parallel to the floor
             base_link_roll: 180.0        # Roll angle (degrees) from camera_init to base_link
             base_link_pitch: -7.5        # Pitch angle (degrees) from camera_init to base_link
             base_link_yaw: 0.0           # Yaw angle (degrees) from camera_init to base_link

--- a/launch/mapping.launch.py
+++ b/launch/mapping.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
         'config_path', default_value=default_config_path,
         description='Yaml config file path'
     )
-    decalre_config_file_cmd = DeclareLaunchArgument(
+    declare_config_file_cmd = DeclareLaunchArgument(
         'config_file', default_value='mid360.yaml',
         description='Config file'
     )
@@ -60,7 +60,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_config_path_cmd)
-    ld.add_action(decalre_config_file_cmd)
+    ld.add_action(declare_config_file_cmd)
     ld.add_action(declare_rviz_cmd)
     ld.add_action(declare_rviz_config_path_cmd)
 

--- a/launch/mapping.launch.py
+++ b/launch/mapping.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
         'config_path', default_value=default_config_path,
         description='Yaml config file path'
     )
-    declare_config_file_cmd = DeclareLaunchArgument(
+    decalre_config_file_cmd = DeclareLaunchArgument(
         'config_file', default_value='mid360.yaml',
         description='Config file'
     )
@@ -60,7 +60,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_config_path_cmd)
-    ld.add_action(declare_config_file_cmd)
+    ld.add_action(decalre_config_file_cmd)
     ld.add_action(declare_rviz_cmd)
     ld.add_action(declare_rviz_config_path_cmd)
 

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -129,12 +129,12 @@ V3D position_last(Zero3d);
 V3D Lidar_T_wrt_IMU(Zero3d);
 M3D Lidar_R_wrt_IMU(Eye3d);
 
-/*** Base link transformation ***/
-bool use_base_link = false;
-M3D base_link_R_flip(Eye3d);  // Rotation from camera_init to base_link
-double base_link_roll = 0.0;   // Roll angle in degrees
-double base_link_pitch = 0.0;  // Pitch angle in degrees
-double base_link_yaw = 0.0;    // Yaw angle in degrees
+/*** Odom transformation ***/
+bool use_odom = false;
+M3D odom_R(Eye3d);  // Rotation from camera_init to odom
+double odom_roll = 0.0;   // Roll angle in degrees
+double odom_pitch = 0.0;  // Pitch angle in degrees
+double odom_yaw = 0.0;    // Yaw angle in degrees
 
 /*** EKF inputs and output ***/
 MeasureGroup Measures;
@@ -197,14 +197,14 @@ void pointBodyToWorld(PointType const * const pi, PointType * const po)
     po->intensity = pi->intensity;
 }
 
-void pointCameraInitToBaseLink(PointType const * const pi, PointType * const po)
+void pointCameraInitToOdom(PointType const * const pi, PointType * const po)
 {
     V3D p_camera_init(pi->x, pi->y, pi->z);
-    V3D p_base_link = base_link_R_flip * p_camera_init;
+    V3D p_odom = odom_R * p_camera_init;
 
-    po->x = p_base_link(0);
-    po->y = p_base_link(1);
-    po->z = p_base_link(2);
+    po->x = p_odom(0);
+    po->y = p_odom(1);
+    po->z = p_odom(2);
     po->intensity = pi->intensity;
 }
 
@@ -609,16 +609,16 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
                             &laserCloudWorld->points[i]);
     }
     
-    // Transform to base_link frame if enabled
-    if (use_base_link)
+    // Transform to odom frame if enabled
+    if (use_odom)
     {
-        PointCloudXYZI::Ptr laserCloudBaseLink(new PointCloudXYZI(size, 1));
+        PointCloudXYZI::Ptr laserCloudOdom(new PointCloudXYZI(size, 1));
         for (int i = 0; i < size; i++)
         {
-            pointCameraInitToBaseLink(&laserCloudWorld->points[i], \
-                                     &laserCloudBaseLink->points[i]);
+            pointCameraInitToOdom(&laserCloudWorld->points[i], \
+                                     &laserCloudOdom->points[i]);
         }
-        *pcl_wait_pub += *laserCloudBaseLink;
+        *pcl_wait_pub += *laserCloudOdom;
     }
     else
     {
@@ -629,7 +629,7 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
     pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = use_base_link ? "base_link" : "camera_init";
+    laserCloudmsg.header.frame_id = use_odom ? "odom" : "camera_init";
     pubLaserCloudMap->publish(laserCloudmsg);
 
     // sensor_msgs::msg::PointCloud2 laserCloudMap;
@@ -866,10 +866,10 @@ public:
         this->declare_parameter<int>("pcd_save.interval", -1);
         this->declare_parameter<vector<double>>("mapping.extrinsic_T", vector<double>());
         this->declare_parameter<vector<double>>("mapping.extrinsic_R", vector<double>());
-        this->declare_parameter<bool>("publish.use_base_link", false);
-        this->declare_parameter<double>("publish.base_link_roll", 180.0);
-        this->declare_parameter<double>("publish.base_link_pitch", 0.0);
-        this->declare_parameter<double>("publish.base_link_yaw", 0.0);
+        this->declare_parameter<bool>("publish.use_odom", false);
+        this->declare_parameter<double>("publish.odom_roll", 180.0);
+        this->declare_parameter<double>("publish.odom_pitch", 0.0);
+        this->declare_parameter<double>("publish.odom_yaw", 0.0);
 
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
@@ -906,31 +906,31 @@ public:
         this->get_parameter_or<int>("pcd_save.interval", pcd_save_interval, -1);
         this->get_parameter_or<vector<double>>("mapping.extrinsic_T", extrinT, vector<double>());
         this->get_parameter_or<vector<double>>("mapping.extrinsic_R", extrinR, vector<double>());
-        this->get_parameter_or<bool>("publish.use_base_link", use_base_link, false);
-        this->get_parameter_or<double>("publish.base_link_roll", base_link_roll, 180.0);
-        this->get_parameter_or<double>("publish.base_link_pitch", base_link_pitch, 0.0);
-        this->get_parameter_or<double>("publish.base_link_yaw", base_link_yaw, 0.0);
+        this->get_parameter_or<bool>("publish.use_odom", use_odom, false);
+        this->get_parameter_or<double>("publish.odom_roll", odom_roll, 180.0);
+        this->get_parameter_or<double>("publish.odom_pitch", odom_pitch, 0.0);
+        this->get_parameter_or<double>("publish.odom_yaw", odom_yaw, 0.0);
 
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
         
-        // Setup base_link transformation with configurable angles
-        if (use_base_link)
+        // Setup odom transformation with configurable angles
+        if (use_odom)
         {
-            RCLCPP_INFO(this->get_logger(), "Base link transformation enabled - map will be published in base_link frame");
-            RCLCPP_INFO(this->get_logger(), "Base link angles (deg): roll=%.2f, pitch=%.2f, yaw=%.2f", 
-                        base_link_roll, base_link_pitch, base_link_yaw);
+            RCLCPP_INFO(this->get_logger(), "Odom transformation enabled - map will be published in odom frame");
+            RCLCPP_INFO(this->get_logger(), "Odom angles (deg): roll=%.2f, pitch=%.2f, yaw=%.2f", 
+                        odom_roll, odom_pitch, odom_yaw);
             
             // Convert degrees to radians
-            double roll_rad = base_link_roll * M_PI / 180.0;
-            double pitch_rad = base_link_pitch * M_PI / 180.0;
-            double yaw_rad = base_link_yaw * M_PI / 180.0;
+            double roll_rad = odom_roll * M_PI / 180.0;
+            double pitch_rad = odom_pitch * M_PI / 180.0;
+            double yaw_rad = odom_yaw * M_PI / 180.0;
             
             // Compute rotation matrix from RPY (ZYX convention)
             double cr = cos(roll_rad), sr = sin(roll_rad);
             double cp = cos(pitch_rad), sp = sin(pitch_rad);
             double cy = cos(yaw_rad), sy = sin(yaw_rad);
             
-            base_link_R_flip << cy*cp, cy*sp*sr - sy*cr, cy*sp*cr + sy*sr,
+            odom_R << cy*cp, cy*sp*sr - sy*cr, cy*sp*cr + sy*sr,
                                 sy*cp, sy*sp*sr + cy*cr, sy*sp*cr - cy*sr,
                                   -sp,           cp*sr,           cp*cr;
         }
@@ -1174,18 +1174,18 @@ private:
     {
         if (map_pub_en) publish_map(pubLaserCloudMap_);
         
-        // Publish static TF: base_link -> camera_init
-        if (use_base_link)
+        // Publish static TF: odom -> camera_init
+        if (use_odom)
         {
-            publish_base_link_tf();
+            publish_odom_tf();
         }
     }
     
-    void publish_base_link_tf()
+    void publish_odom_tf()
     {
         geometry_msgs::msg::TransformStamped static_tf;
         static_tf.header.stamp = this->get_clock()->now();
-        static_tf.header.frame_id = "base_link";
+        static_tf.header.frame_id = "odom";
         static_tf.child_frame_id = "camera_init";
         
         // No translation, only rotation
@@ -1194,7 +1194,7 @@ private:
         static_tf.transform.translation.z = 0.0;
         
         // Convert rotation matrix to quaternion
-        Eigen::Quaterniond q(base_link_R_flip);
+        Eigen::Quaterniond q(odom_R);
         static_tf.transform.rotation.w = q.w();
         static_tf.transform.rotation.x = q.x();
         static_tf.transform.rotation.y = q.y();

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -129,6 +129,13 @@ V3D position_last(Zero3d);
 V3D Lidar_T_wrt_IMU(Zero3d);
 M3D Lidar_R_wrt_IMU(Eye3d);
 
+/*** Base link flip transformation (for upside-down LiDAR) ***/
+bool use_base_link_flip = false;
+M3D base_link_R_flip(Eye3d);  // Rotation from camera_init to base_link
+double base_link_roll = 0.0;   // Roll angle in degrees
+double base_link_pitch = 0.0;  // Pitch angle in degrees
+double base_link_yaw = 0.0;    // Yaw angle in degrees
+
 /*** EKF inputs and output ***/
 MeasureGroup Measures;
 esekfom::esekf<state_ikfom, 12, input_ikfom> kf;
@@ -187,6 +194,17 @@ void pointBodyToWorld(PointType const * const pi, PointType * const po)
     po->x = p_global(0);
     po->y = p_global(1);
     po->z = p_global(2);
+    po->intensity = pi->intensity;
+}
+
+void pointCameraInitToBaseLink(PointType const * const pi, PointType * const po)
+{
+    V3D p_camera_init(pi->x, pi->y, pi->z);
+    V3D p_base_link = base_link_R_flip * p_camera_init;
+
+    po->x = p_base_link(0);
+    po->y = p_base_link(1);
+    po->z = p_base_link(2);
     po->intensity = pi->intensity;
 }
 
@@ -590,13 +608,28 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
         RGBpointBodyToWorld(&laserCloudFullRes->points[i], \
                             &laserCloudWorld->points[i]);
     }
-    *pcl_wait_pub += *laserCloudWorld;
+    
+    // Transform to base_link frame if flip is enabled
+    if (use_base_link_flip)
+    {
+        PointCloudXYZI::Ptr laserCloudBaseLink(new PointCloudXYZI(size, 1));
+        for (int i = 0; i < size; i++)
+        {
+            pointCameraInitToBaseLink(&laserCloudWorld->points[i], \
+                                     &laserCloudBaseLink->points[i]);
+        }
+        *pcl_wait_pub += *laserCloudBaseLink;
+    }
+    else
+    {
+        *pcl_wait_pub += *laserCloudWorld;
+    }
 
     sensor_msgs::msg::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = "camera_init";
+    laserCloudmsg.header.frame_id = use_base_link_flip ? "base_link" : "camera_init";
     pubLaserCloudMap->publish(laserCloudmsg);
 
     // sensor_msgs::msg::PointCloud2 laserCloudMap;
@@ -833,6 +866,10 @@ public:
         this->declare_parameter<int>("pcd_save.interval", -1);
         this->declare_parameter<vector<double>>("mapping.extrinsic_T", vector<double>());
         this->declare_parameter<vector<double>>("mapping.extrinsic_R", vector<double>());
+        this->declare_parameter<bool>("publish.use_base_link_flip", false);
+        this->declare_parameter<double>("publish.base_link_roll", 180.0);
+        this->declare_parameter<double>("publish.base_link_pitch", 0.0);
+        this->declare_parameter<double>("publish.base_link_yaw", 0.0);
 
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
@@ -869,8 +906,34 @@ public:
         this->get_parameter_or<int>("pcd_save.interval", pcd_save_interval, -1);
         this->get_parameter_or<vector<double>>("mapping.extrinsic_T", extrinT, vector<double>());
         this->get_parameter_or<vector<double>>("mapping.extrinsic_R", extrinR, vector<double>());
+        this->get_parameter_or<bool>("publish.use_base_link_flip", use_base_link_flip, false);
+        this->get_parameter_or<double>("publish.base_link_roll", base_link_roll, 180.0);
+        this->get_parameter_or<double>("publish.base_link_pitch", base_link_pitch, 0.0);
+        this->get_parameter_or<double>("publish.base_link_yaw", base_link_yaw, 0.0);
 
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
+        
+        // Setup base_link transformation with configurable angles
+        if (use_base_link_flip)
+        {
+            RCLCPP_INFO(this->get_logger(), "Base link transformation enabled - map will be published in base_link frame");
+            RCLCPP_INFO(this->get_logger(), "Base link angles (deg): roll=%.2f, pitch=%.2f, yaw=%.2f", 
+                        base_link_roll, base_link_pitch, base_link_yaw);
+            
+            // Convert degrees to radians
+            double roll_rad = base_link_roll * M_PI / 180.0;
+            double pitch_rad = base_link_pitch * M_PI / 180.0;
+            double yaw_rad = base_link_yaw * M_PI / 180.0;
+            
+            // Compute rotation matrix from RPY (ZYX convention)
+            double cr = cos(roll_rad), sr = sin(roll_rad);
+            double cp = cos(pitch_rad), sp = sin(pitch_rad);
+            double cy = cos(yaw_rad), sy = sin(yaw_rad);
+            
+            base_link_R_flip << cy*cp, cy*sp*sr - sy*cr, cy*sp*cr + sy*sr,
+                                sy*cp, sy*sp*sr + cy*cr, sy*sp*cr - cy*sr,
+                                  -sp,           cp*sr,           cp*cr;
+        }
 
         path.header.stamp = this->get_clock()->now();
         path.header.frame_id ="camera_init";
@@ -1073,7 +1136,7 @@ private:
             if (scan_pub_en)      publish_frame_world(pubLaserCloudFull_);
             if (scan_pub_en && scan_body_pub_en) publish_frame_body(pubLaserCloudFull_body_);
             if (effect_pub_en) publish_effect_world(pubLaserCloudEffect_);
-            // if (map_pub_en) publish_map(pubLaserCloudMap_);
+            if (map_pub_en || pcd_save_en) publish_map(pubLaserCloudMap_);
 
             /*** Debug variables ***/
             if (runtime_pos_log)
@@ -1110,6 +1173,34 @@ private:
     void map_publish_callback()
     {
         if (map_pub_en) publish_map(pubLaserCloudMap_);
+        
+        // Publish static TF: base_link -> camera_init
+        if (use_base_link_flip)
+        {
+            publish_base_link_tf();
+        }
+    }
+    
+    void publish_base_link_tf()
+    {
+        geometry_msgs::msg::TransformStamped static_tf;
+        static_tf.header.stamp = this->get_clock()->now();
+        static_tf.header.frame_id = "base_link";
+        static_tf.child_frame_id = "camera_init";
+        
+        // No translation, only rotation
+        static_tf.transform.translation.x = 0.0;
+        static_tf.transform.translation.y = 0.0;
+        static_tf.transform.translation.z = 0.0;
+        
+        // Convert rotation matrix to quaternion
+        Eigen::Quaterniond q(base_link_R_flip);
+        static_tf.transform.rotation.w = q.w();
+        static_tf.transform.rotation.x = q.x();
+        static_tf.transform.rotation.y = q.y();
+        static_tf.transform.rotation.z = q.z();
+        
+        tf_broadcaster_->sendTransform(static_tf);
     }
 
     void map_save_callback(std_srvs::srv::Trigger::Request::ConstSharedPtr req, std_srvs::srv::Trigger::Response::SharedPtr res)
@@ -1166,14 +1257,14 @@ int main(int argc, char** argv)
         rclcpp::shutdown();
     /**************** save map ****************/
     /* 1. make sure you have enough memories
-    /* 2. pcd save will largely influence the real-time performences **/
-    if (pcl_wait_save->size() > 0 && pcd_save_en)
+    /* 2. pcd save will largely influence the real-time performances **/
+    if (pcl_wait_pub->size() > 0 && pcd_save_en)
     {
         string file_name = string("scans.pcd");
         string all_points_dir(string(string(ROOT_DIR) + "PCD/") + file_name);
         pcl::PCDWriter pcd_writer;
         cout << "current scan saved to /PCD/" << file_name<<endl;
-        pcd_writer.writeBinary(all_points_dir, *pcl_wait_save);
+        pcd_writer.writeBinary(all_points_dir, *pcl_wait_pub);
     }
 
     if (runtime_pos_log)

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -133,9 +133,13 @@ M3D Lidar_R_wrt_IMU(Eye3d);
 /*** Odom transformation ***/
 bool use_odom = false;
 M3D odom_R(Eye3d);  // Rotation from camera_init to odom
+V3D odom_T(Zero3d); // Translation from camera_init to odom
 double odom_roll = 0.0;   // Roll angle in degrees
 double odom_pitch = 0.0;  // Pitch angle in degrees
 double odom_yaw = 0.0;    // Yaw angle in degrees
+double odom_x = 0.0;      // Translation x in meters
+double odom_y = 0.0;      // Translation y in meters
+double odom_z = 0.0;      // Translation z in meters
 
 /*** EKF inputs and output ***/
 MeasureGroup Measures;
@@ -201,7 +205,7 @@ void pointBodyToWorld(PointType const * const pi, PointType * const po)
 void pointCameraInitToOdom(PointType const * const pi, PointType * const po)
 {
     V3D p_camera_init(pi->x, pi->y, pi->z);
-    V3D p_odom = odom_R * p_camera_init;
+    V3D p_odom = odom_R * p_camera_init + odom_T;
 
     po->x = p_odom(0);
     po->y = p_odom(1);
@@ -868,9 +872,12 @@ public:
         this->declare_parameter<vector<double>>("mapping.extrinsic_T", vector<double>());
         this->declare_parameter<vector<double>>("mapping.extrinsic_R", vector<double>());
         this->declare_parameter<bool>("publish.use_odom", false);
-        this->declare_parameter<double>("publish.odom_roll", 180.0);
+        this->declare_parameter<double>("publish.odom_roll", 0.0);
         this->declare_parameter<double>("publish.odom_pitch", 0.0);
         this->declare_parameter<double>("publish.odom_yaw", 0.0);
+        this->declare_parameter<double>("publish.odom_x", 0.0);
+        this->declare_parameter<double>("publish.odom_y", 0.0);
+        this->declare_parameter<double>("publish.odom_z", 0.0);
 
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
@@ -908,9 +915,12 @@ public:
         this->get_parameter_or<vector<double>>("mapping.extrinsic_T", extrinT, vector<double>());
         this->get_parameter_or<vector<double>>("mapping.extrinsic_R", extrinR, vector<double>());
         this->get_parameter_or<bool>("publish.use_odom", use_odom, false);
-        this->get_parameter_or<double>("publish.odom_roll", odom_roll, 180.0);
+        this->get_parameter_or<double>("publish.odom_roll", odom_roll, 0.0);
         this->get_parameter_or<double>("publish.odom_pitch", odom_pitch, 0.0);
         this->get_parameter_or<double>("publish.odom_yaw", odom_yaw, 0.0);
+        this->get_parameter_or<double>("publish.odom_x", odom_x, 0.0);
+        this->get_parameter_or<double>("publish.odom_y", odom_y, 0.0);
+        this->get_parameter_or<double>("publish.odom_z", odom_z, 0.0);
 
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
         
@@ -920,6 +930,11 @@ public:
             RCLCPP_INFO(this->get_logger(), "Odom transformation enabled - map will be published in odom frame");
             RCLCPP_INFO(this->get_logger(), "Odom angles (deg): roll=%.2f, pitch=%.2f, yaw=%.2f", 
                         odom_roll, odom_pitch, odom_yaw);
+            RCLCPP_INFO(this->get_logger(), "Odom translation (m): x=%.2f, y=%.2f, z=%.2f", 
+                        odom_x, odom_y, odom_z);
+            
+            // Set translation vector
+            odom_T << odom_x, odom_y, odom_z;
             
             // Convert degrees to radians
             double roll_rad = odom_roll * M_PI / 180.0;
@@ -1190,9 +1205,9 @@ private:
         static_tf.child_frame_id = "camera_init";
         
         // No translation, only rotation
-        static_tf.transform.translation.x = 0.0;
-        static_tf.transform.translation.y = 0.0;
-        static_tf.transform.translation.z = 0.0;
+        static_tf.transform.translation.x = odom_T(0);
+        static_tf.transform.translation.y = odom_T(1);
+        static_tf.transform.translation.z = odom_T(2);
         
         // Convert rotation matrix to quaternion
         Eigen::Quaterniond q(odom_R);

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -129,8 +129,8 @@ V3D position_last(Zero3d);
 V3D Lidar_T_wrt_IMU(Zero3d);
 M3D Lidar_R_wrt_IMU(Eye3d);
 
-/*** Base link flip transformation (for upside-down LiDAR) ***/
-bool use_base_link_flip = false;
+/*** Base link transformation ***/
+bool use_base_link = false;
 M3D base_link_R_flip(Eye3d);  // Rotation from camera_init to base_link
 double base_link_roll = 0.0;   // Roll angle in degrees
 double base_link_pitch = 0.0;  // Pitch angle in degrees
@@ -609,8 +609,8 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
                             &laserCloudWorld->points[i]);
     }
     
-    // Transform to base_link frame if flip is enabled
-    if (use_base_link_flip)
+    // Transform to base_link frame if enabled
+    if (use_base_link)
     {
         PointCloudXYZI::Ptr laserCloudBaseLink(new PointCloudXYZI(size, 1));
         for (int i = 0; i < size; i++)
@@ -629,7 +629,7 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
     pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = use_base_link_flip ? "base_link" : "camera_init";
+    laserCloudmsg.header.frame_id = use_base_link ? "base_link" : "camera_init";
     pubLaserCloudMap->publish(laserCloudmsg);
 
     // sensor_msgs::msg::PointCloud2 laserCloudMap;
@@ -866,7 +866,7 @@ public:
         this->declare_parameter<int>("pcd_save.interval", -1);
         this->declare_parameter<vector<double>>("mapping.extrinsic_T", vector<double>());
         this->declare_parameter<vector<double>>("mapping.extrinsic_R", vector<double>());
-        this->declare_parameter<bool>("publish.use_base_link_flip", false);
+        this->declare_parameter<bool>("publish.use_base_link", false);
         this->declare_parameter<double>("publish.base_link_roll", 180.0);
         this->declare_parameter<double>("publish.base_link_pitch", 0.0);
         this->declare_parameter<double>("publish.base_link_yaw", 0.0);
@@ -906,7 +906,7 @@ public:
         this->get_parameter_or<int>("pcd_save.interval", pcd_save_interval, -1);
         this->get_parameter_or<vector<double>>("mapping.extrinsic_T", extrinT, vector<double>());
         this->get_parameter_or<vector<double>>("mapping.extrinsic_R", extrinR, vector<double>());
-        this->get_parameter_or<bool>("publish.use_base_link_flip", use_base_link_flip, false);
+        this->get_parameter_or<bool>("publish.use_base_link", use_base_link, false);
         this->get_parameter_or<double>("publish.base_link_roll", base_link_roll, 180.0);
         this->get_parameter_or<double>("publish.base_link_pitch", base_link_pitch, 0.0);
         this->get_parameter_or<double>("publish.base_link_yaw", base_link_yaw, 0.0);
@@ -914,7 +914,7 @@ public:
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
         
         // Setup base_link transformation with configurable angles
-        if (use_base_link_flip)
+        if (use_base_link)
         {
             RCLCPP_INFO(this->get_logger(), "Base link transformation enabled - map will be published in base_link frame");
             RCLCPP_INFO(this->get_logger(), "Base link angles (deg): roll=%.2f, pitch=%.2f, yaw=%.2f", 
@@ -1136,7 +1136,7 @@ private:
             if (scan_pub_en)      publish_frame_world(pubLaserCloudFull_);
             if (scan_pub_en && scan_body_pub_en) publish_frame_body(pubLaserCloudFull_body_);
             if (effect_pub_en) publish_effect_world(pubLaserCloudEffect_);
-            if (map_pub_en || pcd_save_en) publish_map(pubLaserCloudMap_);
+            if (map_pub_en) publish_map(pubLaserCloudMap_);
 
             /*** Debug variables ***/
             if (runtime_pos_log)
@@ -1175,7 +1175,7 @@ private:
         if (map_pub_en) publish_map(pubLaserCloudMap_);
         
         // Publish static TF: base_link -> camera_init
-        if (use_base_link_flip)
+        if (use_base_link)
         {
             publish_base_link_tf();
         }

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -57,6 +57,7 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <livox_ros_driver2/msg/custom_msg.hpp>
@@ -997,6 +998,12 @@ public:
         pubOdomAftMapped_ = this->create_publisher<nav_msgs::msg::Odometry>("/Odometry", 20);
         pubPath_ = this->create_publisher<nav_msgs::msg::Path>("/path", 20);
         tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+        static_tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
+        
+        if (use_odom)
+        {
+            publish_odom_tf();
+        }
 
         //------------------------------------------------------------------------------------------------------
         auto period_ms = std::chrono::milliseconds(static_cast<int64_t>(1000.0 / 100.0));
@@ -1173,12 +1180,6 @@ private:
     void map_publish_callback()
     {
         if (map_pub_en) publish_map(pubLaserCloudMap_);
-        
-        // Publish static TF: odom -> camera_init
-        if (use_odom)
-        {
-            publish_odom_tf();
-        }
     }
     
     void publish_odom_tf()
@@ -1200,7 +1201,7 @@ private:
         static_tf.transform.rotation.y = q.y();
         static_tf.transform.rotation.z = q.z();
         
-        tf_broadcaster_->sendTransform(static_tf);
+        static_tf_broadcaster_->sendTransform(static_tf);
     }
 
     void map_save_callback(std_srvs::srv::Trigger::Request::ConstSharedPtr req, std_srvs::srv::Trigger::Response::SharedPtr res)
@@ -1231,6 +1232,7 @@ private:
     rclcpp::Subscription<livox_ros_driver2::msg::CustomMsg>::SharedPtr sub_pcl_livox_;
 
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+    std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
     rclcpp::TimerBase::SharedPtr timer_;
     rclcpp::TimerBase::SharedPtr map_pub_timer_;
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr map_save_srv_;


### PR DESCRIPTION
Add a function to allow different mounting orientation of the 3D LiDAR, if the lidar mounting is not parallel to the floor. Mainly can be used in unitree robot model, such as Unitree G1.